### PR TITLE
Revert cryptography library version

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -38,9 +38,9 @@ jobs:
     - name: Create public_key file
       run: |
         cat > /home/runner/work/photonranch-calendar/photonranch-calendar/public_key << EOF
-        -----BEGIN CERTIFICATE-----
+        -----BEGIN PUBLIC KEY-----
         ${{ secrets.AUTH0_PUBLIC_KEY }}
-        -----END CERTIFICATE-----
+        -----END PUBLIC KEY-----
         EOF
         
     - name: Create Auth0 secrets file

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -38,9 +38,9 @@ jobs:
     - name: Create public_key file
       run: |
         cat > /home/runner/work/photonranch-calendar/photonranch-calendar/public_key << EOF
-        -----BEGIN PUBLIC KEY-----
+        -----BEGIN CERTIFICATE-----
         ${{ secrets.AUTH0_PUBLIC_KEY }}
-        -----END PUBLIC KEY-----
+        -----END CERTIFICATE-----
         EOF
         
     - name: Create Auth0 secrets file

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.24.18
 certifi==2022.6.15
 cffi==1.15.0
 chardet==5.0.0
-cryptography==37.0.2
+cryptography==2.3
 idna==3.3
 moto==3.1.15
 pycparser==2.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.24.18
 certifi==2022.6.15
 cffi==1.15.0
 chardet==5.0.0
-cryptography==2.3
+cryptography==3.3.1
 idna==3.3
 moto==3.1.15
 pycparser==2.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.24.18
 certifi==2022.6.15
 cffi==1.15.0
 chardet==5.0.0
-cryptography==3.3.1
+cryptography==37.0.2
 idna==3.3
 moto==3.1.15
 pycparser==2.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.24.18
 certifi==2022.6.15
 cffi==1.15.0
 chardet==5.0.0
-cryptography==37.0.2
+cryptography==3.3.1
 idna==3.3
 moto==3.1.15
 pycparser==2.21


### PR DESCRIPTION
Cryptography version 37.0.2 raised the following exception in the authorizer function:
```
Exception encountered: Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. InvalidData(InvalidByte(64, 32))
```
I am not sure why the PEM file could not be loaded with 37.0.2, but it works fine with version 3.3.2.