### PR TITLE
Add endpoint for removing expired lco scheduler events

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -3,6 +3,8 @@ name: Deploy Script
 on:
   push:
     branches: [main, dev]
+    paths-ignore:
+      - 'README.md'
       
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The body of a calendar event follows the JSON format below:
     "site": "saf",  // Sitecode where reservation was made
     "title": "My Name",  // Name of reservation, defaults to username
     "reservation_type": "realtime",  // String, can be "realtime" or "project"
+    "origin": "ptr", // "ptr" if created on the ptr site, or "lco" if the event was created by the lco scheduler
     "resourceId": "saf",  // Sitecode where reservation was made
     "project_id": "none",  // Or concatenated string of project_name#created_at timestamp
     "reservation_note": "",  // User-supplied comment string, can be empty

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ The body of a calendar event follows the JSON format below:
 ```javascript
 {
     "event_id": "024242f...",  // Unique ID generated for each new reservation
-    "start": "2022-06-20T06:15:00Z",  // Starting UTC date and time of reservation
-    "end": "2022-06-20T06:45:00Z",  // Ending UTC date and time of reservation
+    "start": "2022-06-20T16:15:00Z",  // Starting UTC date and time of reservation
+    "end": "2022-06-20T16:45:00Z",  // Ending UTC date and time of reservation
     "creator": "Firstname Lastname",  // String of user display name
     "creator_id": "google-oauth2|xxxxxxxxxxxxx",  // Auth0 user 'sub' string
     "site": "saf",  // Sitecode where reservation was made
@@ -93,6 +93,8 @@ The body of a calendar event follows the JSON format below:
 ## API Endpoints
 
 Calendar requests are handled at the base URL `https://calendar.photonranch.org/{stage}`, where `{stage}` is `dev` for the dev environment, or `calendar` for the production version.
+
+All datetimes should be formatted yyyy-MM-ddTHH:mmZ (UTC, 24-hour format)
 
 - POST `/newevent`
   - Description: Create a new reservation on the calendar.
@@ -124,6 +126,17 @@ Calendar requests are handled at the base URL `https://calendar.photonranch.org/
   - Authorization required: No.
   - Request body:
     - `events` (array): dictionaries for each calendar event to update.
+  - Responses:
+    - 200: success.
+
+- POST `/remove-expired-lco-schedule`
+  - Description: Removes all events at a given site under the following conditions:
+    - the event `origin` == "lco"
+    - the event `start` is after (greater than) the specified cutoff_time
+  - Authorization required: No.
+  - Request body:
+    - `site` (string): dictionaries for each calendar event to update
+    - `cutoff_time` (string): UTC datestring, which is compared against the `start` attribute
   - Responses:
     - 200: success.
 

--- a/handler.py
+++ b/handler.py
@@ -443,7 +443,7 @@ def clearExpiredSchedule(event, context):
     """
     event_body = json.loads(event.get("body", ""))
     remove_expired_scheduler_events(event_body["cutoff_time"], event_body["site"])
-    return create_response(200)
+    return create_response(200, "success")
 
 
 def getSiteEventsInDateRange(event, context):

--- a/serverless.yml
+++ b/serverless.yml
@@ -65,6 +65,7 @@ provider:
             - "dynamodb:Scan"
             - "dynamodb:Query"
             - "dynamodb:DescribeTable"
+            - "dynamodb:BatchWriteItem"
           Resource:
             - "arn:aws:dynamodb:${self:provider.region}:*:table/${self:custom.calendarTableName}*"
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -64,6 +64,7 @@ provider:
             - "dynamodb:DeleteItem"
             - "dynamodb:Scan"
             - "dynamodb:Query"
+            - "dynamodb:DescribeTable"
           Resource:
             - "arn:aws:dynamodb:${self:provider.region}:*:table/${self:custom.calendarTableName}*"
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -265,7 +265,13 @@ functions:
               - X-Amz-User-Agent
               - Access-Control-Allow-Origin
               - Access-Control-Allow-Credentials
-
+  clearExpiredSchedule:
+    handler: handler.clearExpiredSchedule
+    events:
+      - http:
+          path: remove-expired-lco-schedule
+          method: post 
+          cors: true
   getSiteEventsInDateRange:
     handler: handler.getSiteEventsInDateRange
     events:


### PR DESCRIPTION
This PR adds a new endpoint to the calendar api that helps with managing events created by the LCO scheduler. 

Any events that are created from the scheduler will have the `origin` attribute as "lco". When new schedules for a site replace existing events, this endpoint will be used to clear the ptr calendar of the now-outdated events. It works using a query for all events at a given site where the start date is after a provided cutoff threshold, and the origin is "lco". 

The endpoint will return a list of project_ids for any photon ranch projects that were scheduled during any of the deleted events. These projects will need to be deleted as well (though that doesn't happen here). 

Also added a small change to the deployment script so that it doesn't run if the readme is the only file modified. 